### PR TITLE
Adds option to replace default undefined character

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ __NOTE: ruby >= 1.9.2 is required__
     # replaces unsupported chars with '?'
     GSMEncoder.encode('`') # => '?'
 
+    # replaces unsupported chars with a provided value ' '
+    GSMEncoder.encode('`', ' ') # => ' '
+
 ## Updates
 
 ### 0.1.1
@@ -35,3 +38,8 @@ Added support for Spanish shift
 ### 0.1.2
 
 Fixed bug when encoding line feed & carriage return
+
+## 0.1.3
+
+Adds the ability to provide the character used when encoding
+unsupported strings

--- a/gsm_encoder.gemspec
+++ b/gsm_encoder.gemspec
@@ -4,7 +4,7 @@ lib = File.expand_path('../lib/', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "gsm_encoder"
-  s.version     = "0.1.2"
+  s.version     = "0.1.3"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Yury Korolev", "Jeff Webb"]
   s.email       = ["yury.korolev@gmail.com", "jeff@boowebb.com"]

--- a/lib/gsm_encoder.rb
+++ b/lib/gsm_encoder.rb
@@ -7,6 +7,7 @@
 # alphabet. It also supports the default extension table. The default alphabet
 # and it's extension table is defined in GSM 03.38.
 module GSMEncoder
+  DEFAULT_REPLACE_CHAR = "?"
 
   EXTENDED_ESCAPE = 0x1b
   NL = 10.chr
@@ -78,8 +79,10 @@ module GSMEncoder
     true
   end
 
-  def encode str
+  def encode(str, replace_char=nil)
     return nil if !str
+
+    replace_char = DEFAULT_REPLACE_CHAR if !replace_char || !can_encode?(replace_char)
 
     buffer = ''.encode('binary')
 
@@ -103,7 +106,7 @@ module GSMEncoder
           search += 1
         end
         if search == CHAR_TABLE.length
-          buffer << '?'
+          buffer << replace_char
         end
       end
     rescue

--- a/test/gsm_encoder_test.rb
+++ b/test/gsm_encoder_test.rb
@@ -12,6 +12,36 @@ class GSMEncoderTest < Test::Unit::TestCase
     assert_equal '', encode('')
   end
 
+  def test_custom_replacements_for_unsupported_chars
+    assert_equal '      ', encode('привет', " ")
+    assert_equal ' ', encode('`', " ")
+
+    # unsupported Spanish characters
+    assert_equal ' ', encode('ï', " ")
+
+    # unsupported French characters
+    assert_equal ' ',  encode('À', " ")
+    assert_equal '  ', encode('Ââ', " ")
+    assert_equal ' ',  encode('È', " ")
+    assert_equal '  ', encode('Êê', " ")
+    assert_equal '  ', encode('Ëë', " ")
+    assert_equal '  ', encode('Îî', " ")
+    assert_equal '  ', encode('Ïï', " ")
+    assert_equal '  ', encode('Ôô', " ")
+    assert_equal '  ', encode('Œœ', " ")
+    assert_equal ' ',  encode('Ù', " ")
+    assert_equal '  ', encode('Ûû', " ")
+    assert_equal '  ', encode('Ÿÿ', " ")
+
+    # unsupported Czech characters
+    assert_equal '                    ', encode('ČčĎďĚěŇňŘřŠšŤťŮůÝýŽž', " ")
+
+  end
+
+  def test_custom_replacement_using_unsupported_char
+    assert_equal '??????', encode('привет', "ï")
+  end
+
   def test_replacements_for_unsupported_chars
     assert_equal '??????', encode('привет')
     assert_equal '?', encode('`')


### PR DESCRIPTION
When encoding a string that has unsupported characters, the unsupported characters are replaced with a default valid character.

This allows you to define that replacement character rather than just defaulting to "?"
